### PR TITLE
refactor: auto accept created invitation

### DIFF
--- a/packages/siera-ui/src/components/connections/ConnectionsTable.tsx
+++ b/packages/siera-ui/src/components/connections/ConnectionsTable.tsx
@@ -14,8 +14,6 @@ import { TableHead } from '../generic/table/TableHeader'
 interface ConnectionsTableProps {
   records: ConnectionRecord[]
   onDelete: (connection: ConnectionRecord) => void
-  onAccept: (connection: ConnectionRecord) => void
-  onDecline: (connection: ConnectionRecord) => void
 }
 
 const useStyles = createStyles(() => ({
@@ -26,7 +24,7 @@ const useStyles = createStyles(() => ({
   },
 }))
 
-export const ConnectionsTable = ({ records, onDelete, onAccept, onDecline }: ConnectionsTableProps) => {
+export const ConnectionsTable = ({ records, onDelete }: ConnectionsTableProps) => {
   const { classes: tableStyle, cx } = useGenericTableStyle()
   const { classes } = useStyles()
   const navigation = useNavigation()
@@ -50,8 +48,6 @@ export const ConnectionsTable = ({ records, onDelete, onAccept, onDecline }: Con
         <tbody>
           {records.map((record: ConnectionRecord) => {
             const isLoading = ConnectionsUtil.isConnectionWaitingForResponse(record)
-            const isWaitingForAccept = ConnectionsUtil.isConnectionWaitingForAcceptInput(record)
-            const isWaitingForDecline = ConnectionsUtil.isConnectionWaitingForDeclineInput(record)
 
             const lastUpdated = record.updatedAt ?? record.createdAt
 
@@ -78,12 +74,7 @@ export const ConnectionsTable = ({ records, onDelete, onAccept, onDecline }: Con
                   <StatusBadge>{record.state}</StatusBadge>
                 </td>
                 <td>
-                  <RecordActions
-                    onAccept={isWaitingForAccept ? () => onAccept(record) : undefined}
-                    onDecline={isWaitingForDecline ? () => onDecline(record) : undefined}
-                    onDelete={() => onDelete(record)}
-                    isLoading={isLoading}
-                  />
+                  <RecordActions onDelete={() => onDelete(record)} isLoading={isLoading} />
                 </td>
               </tr>
             )

--- a/packages/siera-ui/src/pages/agent/connections/ConnectionsScreen.tsx
+++ b/packages/siera-ui/src/pages/agent/connections/ConnectionsScreen.tsx
@@ -25,16 +25,10 @@ export const ConnectionsScreen = () => {
     await agent?.oob.receiveInvitationFromUrl(url)
   }
 
-  const acceptRequest = async (connectionId: string) => {
-    await agent?.connections.acceptRequest(connectionId)
-  }
-
-  const declineRequest = async (connectionId: string) => {
-    await agent?.connections.deleteById(connectionId)
-  }
-
   const createInvite = async () => {
-    const invite = await agent?.oob.createLegacyInvitation()
+    const invite = await agent?.oob.createLegacyInvitation({
+      autoAcceptConnection: true,
+    })
 
     if (!invite) {
       showNotification({
@@ -81,8 +75,6 @@ export const ConnectionsScreen = () => {
           <ConnectionsTable
             records={connectionRecords}
             onDelete={(connection) => agent?.connections.deleteById(connection.id)}
-            onAccept={(connection) => acceptRequest(connection.id)}
-            onDecline={(connection) => declineRequest(connection.id)}
           />
         </Card>
       )}


### PR DESCRIPTION
This PR removes the accept button from the connection list when you receive a request for an invitation you created. I think most wallets expect a connection to be completed immediately (it's just a cryptographic relation). 

If not desired, feel free to close this PR, but wanted to tinker a bit with Siera.

We may want to look at the flickering of the states as that now happens almost immediately (see video)



https://user-images.githubusercontent.com/23165168/224819530-1e89c9dd-0b59-4f74-8dce-709393f45cb8.mov

